### PR TITLE
refactor(monkey_patches) remove monkey patches for improved graphql-ruby API 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 cache: bundler
 sudo: required
 rvm:
-  - 2.1
   - 2.2
 addons:
   apt:
@@ -16,10 +15,10 @@ before_install:
   - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-5 /usr/bin/g++
   - g++ --version
   - sudo apt-get install bison
-  - wget https://github.com/graphql/libgraphqlparser/archive/v0.4.0.tar.gz
-  - tar -xzvf v0.4.0.tar.gz
-  - cd libgraphqlparser-0.4.0/ && sudo cmake . && sudo make && sudo make install
+  - wget https://github.com/graphql/libgraphqlparser/archive/v0.4.1.tar.gz
+  - tar -xzvf v0.4.1.tar.gz
+  - cd libgraphqlparser-0.4.1/ && sudo cmake . && sudo make && sudo make install
   - gem update --system
   - gem install bundler
 script:
-  - bundle exec rake
+  - bundle exec rake --trace

--- a/README.md
+++ b/README.md
@@ -43,9 +43,3 @@ When you `require` this gem, it overrides `GraphQL.parse`:
 ```ruby
 require "graphql/libgraphqlparser"
 ```
-
-## Todo
-
-- Get directives from OperationDefinitions
-- AbstractNode overrides are full of tension. Resolve that tension with GraphQL main.
-- Node `#type` is sometimes a String, sometimes a Node. That should always be the same.

--- a/graphql-libgraphqlparser.gemspec
+++ b/graphql-libgraphqlparser.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'graphql', '~> 0.10.0'
+  spec.add_runtime_dependency 'graphql', '~> 0.11.0'
 
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.add_development_dependency "guard", "~> 2.12"

--- a/lib/graphql/libgraphqlparser/monkey_patches/abstract_node.rb
+++ b/lib/graphql/libgraphqlparser/monkey_patches/abstract_node.rb
@@ -1,40 +1,6 @@
 module GraphQL
   module Language
     module Nodes
-      class AbstractNode
-        alias :old_initialize :initialize
-        # Allow initialize with no args
-        def initialize(*args)
-          if args.any?
-            old_initialize(*args)
-          end
-        end
-
-        def position
-          [line, col]
-        end
-      end
-
-      # Document = AbstractNode.create(:parts)
-      class Document
-        def definitions
-          @parts ||= []
-        end
-      end
-
-      # OperationDefinition = AbstractNode.create(:operation_type, :name, :variables, :directives, :selections)
-      class OperationDefinition
-        def variables
-          @variables ||= []
-        end
-
-        def selections
-          @selections ||= []
-        end
-      end
-
-      # Variable = AbstractNode.create(:name, :type, :default_value)
-      VariableDefinition = Variable
       class VariableDefinition
         # Make it behave like an Argument
         def value=(new_value)
@@ -42,57 +8,6 @@ module GraphQL
         end
       end
 
-      # VariableIdentifier = AbstractNode.create(:name)
-
-      # FragmentDefinition = AbstractNode.create(:name, :type, :directives, :selections)
-      class FragmentDefinition
-        def selections
-          @selections ||= []
-        end
-      end
-
-      # Field = AbstractNode.create(:name, :alias, :arguments, :directives, :selections)
-      class Field
-        def selections
-          @selections ||= []
-        end
-
-        def directives
-          @directives ||= []
-        end
-
-        def arguments
-          @arguments ||= []
-        end
-      end
-
-      # Directive = AbstractNode.create(:name, :arguments)
-      class Directive
-        def arguments
-          @arguments ||= []
-        end
-      end
-
-      # FragmentSpread = AbstractNode.create(:name, :directives)
-      class FragmentSpread
-        def directives
-          @directives ||= []
-        end
-      end
-
-      # InlineFragment = AbstractNode.create(:type, :directives, :selections)
-      class InlineFragment
-        def directives
-          @directives ||= []
-        end
-        def selections
-          @selections ||= []
-        end
-      end
-
-      # ListType = AbstractNode.create(:of_type)
-      # NonNullType = AbstractNode.create(:of_type)
-      # TypeName = AbstractNode.create(:name)
       class ListType
         def type=(inner_type)
           self.of_type = inner_type
@@ -106,13 +21,7 @@ module GraphQL
         def type; self.of_type; end
       end
 
-      # Argument = AbstractNode.create(:name, :value)
-      # Enum = AbstractNode.create(:name)
-      class InputObject
-        def arguments
-          @pairs ||= []
-        end
-      end
+
 
       class ArrayLiteral < AbstractNode
         attr_reader :values

--- a/test/graphql/libgraphqlparser_test.rb
+++ b/test/graphql/libgraphqlparser_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe GraphQL::Libgraphqlparser do
   let(:document) { GraphQL::Libgraphqlparser.parse(query_string) }
   let(:query_string) {%|
-    query getStuff($someVar: Int = 1, $anotherVar: [String!] ) {
+    query getStuff($someVar: Int = 1, $anotherVar: [String!] ) @skip(if: false) {
       myField: someField(someArg: $someVar, ok: 1.4) @skip(if: $anotherVar) @thing(or: "Whatever")
 
       anotherField(someArg: [1,2,3]) {
@@ -18,7 +18,7 @@ describe GraphQL::Libgraphqlparser do
 
     }
 
-    fragment moreNestedFields on NestedType {
+    fragment moreNestedFields on NestedType @or(something: "ok") {
       anotherNestedField
     }
   |}
@@ -43,6 +43,7 @@ describe GraphQL::Libgraphqlparser do
         assert_equal "query", query.operation_type
         assert_equal 2, query.variables.length
         assert_equal 3, query.selections.length
+        assert_equal 1, query.directives.length
         assert_equal [2, 5], [query.line, query.col]
       end
 
@@ -51,6 +52,7 @@ describe GraphQL::Libgraphqlparser do
         assert_equal "moreNestedFields", fragment_def.name
         assert_equal 1, fragment_def.selections.length
         assert_equal "NestedType", fragment_def.type
+        assert_equal 1, fragment_def.directives.length
         assert_equal [17, 5], fragment_def.position
       end
 


### PR DESCRIPTION
After merging rmosolgo/graphql-ruby#92, won't need this crazy monkey patching
