### PR TITLE
Use libgraphqlparser if installed with a /usr prefix.

### DIFF
--- a/ext/graphql_libgraphqlparser_ext/extconf.rb
+++ b/ext/graphql_libgraphqlparser_ext/extconf.rb
@@ -1,6 +1,12 @@
 require 'mkmf'
 
-dir_config('graphql', '/usr/local/include/graphqlparser', '/usr/local/lib')
-abort 'missing libgraphqlparser' unless have_library 'graphqlparser'
+prefixes = %w(/usr /usr/local)
+if prefix = prefixes.find{ |prefix| Dir["#{prefix}/lib/libgraphqlparser*"].first }
+  dir_config('graphql', "#{prefix}/include/graphqlparser", "#{prefix}/lib")
+else
+  dir_config('graphql')
+end
+abort 'missing libgraphqlparser' unless have_library('graphqlparser')
+abort 'missing libgraphqlparser headers' unless have_header('c/GraphQLParser.h')
 
 create_makefile "graphql_libgraphqlparser_ext"


### PR DESCRIPTION
## Problem

I'm trying to create an ubuntu package for libgraphqlparser, which normally installs packages to the /usr prefix.  However, graphql-libgraphqlparser-ruby only looks for libgraphqlparser under the /usr/local prefix.
## Solution

Look for the library in either the /usr or /usr/local to determine the prefix.  I also added a check for a header to make sure the headers are also installed, since typically there is a package with just the shared library and a dev package with the headers.
