### PR TITLE
Use StringValueCStr instead of StringValuePtr for null termination.

### DIFF
--- a/ext/graphql_libgraphqlparser_ext/graphql_libgraphqlparser_ext.c
+++ b/ext/graphql_libgraphqlparser_ext/graphql_libgraphqlparser_ext.c
@@ -13,7 +13,7 @@ static struct GraphQLAstVisitorCallbacks Libgraphqlparser_Callbacks;
 // Given a Ruby querystring, return a
 // GraphQL::Nodes::Document instance.
 VALUE GraphQL_Libgraphqlparser_parse(VALUE self, VALUE query_string) {
-  const char* c_query_string = StringValuePtr(query_string);
+  const char* c_query_string = StringValueCStr(query_string);
   const char* parse_error_message;
   VALUE exception;
   VALUE builder = Qnil;


### PR DESCRIPTION
@rmosolgo please review
@eapache noticed this bug

The [ruby extension documentation](https://github.com/ruby/ruby/blob/v2_3_0/doc/extension.rdoc#convert-value-into-c-data) says

> You can also use the macro named StringValueCStr(). This is just like StringValuePtr(), but always add nul character at the end of the result. If the result contains nul character, this macro causes the ArgumentError exception. StringValuePtr() doesn't guarantee the existence of a nul at the end of the result, and the result may contain nul.

however, this gem's extension was using StringValuePtr and not assuming the returned string was null terminated, so I changed it to use StringValueCStr instead.

By the way, we are curious about why you chose not to use https://github.com/Shopify/graphql-parser
