### PR TITLE
Fix inline fragments without a type condition.

### DIFF
--- a/ext/graphql_libgraphqlparser_ext/visitor_functions.c
+++ b/ext/graphql_libgraphqlparser_ext/visitor_functions.c
@@ -39,7 +39,7 @@
       )                                       \
     );                                        \
 
-#define ASSIGN_NAMED_TYPE(get_type_fn)    \
+#define ASSIGN_NAMED_TYPE(type)           \
   rb_funcall(                             \
     rb_node,                              \
     type_set_intern,                      \
@@ -47,7 +47,7 @@
     rb_str_new2(                          \
       GraphQLAstName_get_value(           \
         GraphQLAstNamedType_get_name(     \
-          get_type_fn(node)               \
+          type                            \
         )                                 \
       )                                   \
     )                                     \
@@ -127,7 +127,8 @@ void variable_definition_end_visit(const struct GraphQLAstVariableDefinition* no
 int fragment_definition_begin_visit(const struct GraphQLAstFragmentDefinition* node, void* builder_ptr) {
   BEGIN("FragmentDefinition")
   ASSIGN_NAME(GraphQLAstFragmentDefinition_get_name)
-  ASSIGN_NAMED_TYPE(GraphQLAstFragmentDefinition_get_type_condition)
+  const struct GraphQLAstNamedType *type = GraphQLAstFragmentDefinition_get_type_condition(node);
+  ASSIGN_NAMED_TYPE(type)
   return 1;
 }
 
@@ -197,7 +198,11 @@ void fragment_spread_end_visit(const struct GraphQLAstFragmentSpread* node, void
 
 int inline_fragment_begin_visit(const struct GraphQLAstInlineFragment* node, void* builder_ptr) {
   BEGIN("InlineFragment")
-  ASSIGN_NAMED_TYPE(GraphQLAstInlineFragment_get_type_condition)
+  const struct GraphQLAstNamedType *type = GraphQLAstInlineFragment_get_type_condition(node);
+  if (type) {
+    ASSIGN_NAMED_TYPE(type)
+  }
+
   return 1;
 }
 

--- a/test/graphql/libgraphqlparser_test.rb
+++ b/test/graphql/libgraphqlparser_test.rb
@@ -148,6 +148,15 @@ describe GraphQL::Libgraphqlparser do
         it "gets position info" do
           assert_equal [10, 7], inline_fragment.position
         end
+
+        describe "without type condition" do
+          let(:query_string) { 'query { ... @skip(if: false) { field } }' }
+          let(:inline_fragment) { query.selections[0] }
+          it "gets directives and nil type" do
+            assert_equal nil, inline_fragment.type
+            assert_equal 1, inline_fragment.directives.length
+          end
+        end
       end
 
       describe "inputs" do


### PR DESCRIPTION
## Problem

A graphql query with an inline fragment that doesn't have a type condition will crash this repo's c extension.

E.g.

``` graphql
query {
  ... @skip(if: false) {
    field
  }
}
```

Notice in the [Inline Fragments section of the graphql spec](http://facebook.github.io/graphql/#sec-Inline-Fragments) that the type condition is optional, along with examples showing how it can be used without a type condition.
## Solution

Check the return value of `GraphQLAstInlineFragment_get_type_condition` to make sure it is non-NULL before using it in the ASSIGN_NAMED_TYPE macro.
