### PR TITLE
map GraphQL::Libgraphqlparser::ParseError to GraphQL::ParseError

### DIFF
--- a/lib/graphql/libgraphqlparser.rb
+++ b/lib/graphql/libgraphqlparser.rb
@@ -7,8 +7,19 @@ require_relative '../graphql_libgraphqlparser_ext'
 module GraphQL
   module Libgraphqlparser
     def self.parse(string)
-      builder = builder_parse(string)
-      builder.document
+      begin
+        builder = builder_parse(string)
+        builder.document
+      rescue ParseError => e
+        error_message = e.message.match(/(\d+)\.(\d+): (.*)/)
+        if error_message
+          line = error_message[1].to_i
+          col = error_message[2].to_i
+          raise GraphQL::ParseError.new(error_message[3], line, col, string)
+        else
+          raise GraphQL::ParseError.new(e.message, nil, nil, string)
+        end
+      end
     end
   end
 

--- a/test/graphql/libgraphqlparser_test.rb
+++ b/test/graphql/libgraphqlparser_test.rb
@@ -237,7 +237,7 @@ describe GraphQL::Libgraphqlparser do
   describe "errors" do
     let(:query_string) {%| query doSomething { bogus { } |}
     it "raises a parse error" do
-      err = assert_raises(GraphQL::Libgraphqlparser::ParseError) { document }
+      err = assert_raises(GraphQL::ParseError) { document }
     end
   end
 end


### PR DESCRIPTION
This will map `GraphQL::Libgraphqlparser::ParseError` to `GraphQL::ParseError`.
