### PR TITLE
Raise a parse error if the query string contains a null byte.

### DIFF
--- a/lib/graphql/libgraphqlparser.rb
+++ b/lib/graphql/libgraphqlparser.rb
@@ -10,6 +10,14 @@ module GraphQL
       begin
         builder = builder_parse(string)
         builder.document
+      rescue ArgumentError
+        if index = string.index("\x00")
+          string_before_null = string.slice(0, index)
+          line = string_before_null.count("\n") + 1
+          col = index - string_before_null.rindex("\n") || 0
+          raise GraphQL::ParseError.new("Invalid null byte in query", line, col, string)
+        end
+        raise
       rescue ParseError => e
         error_message = e.message.match(/(\d+)\.(\d+): (.*)/)
         if error_message

--- a/test/graphql/libgraphqlparser_test.rb
+++ b/test/graphql/libgraphqlparser_test.rb
@@ -239,5 +239,14 @@ describe GraphQL::Libgraphqlparser do
     it "raises a parse error" do
       err = assert_raises(GraphQL::ParseError) { document }
     end
+
+    it "raises a parse error in query with null byte" do
+      err = assert_raises(GraphQL::ParseError) do
+        GraphQL::Libgraphqlparser.parse("mutation{\nsend(message: \"null\x00byte\")\n}")
+      end
+      assert_equal err.message, "Invalid null byte in query"
+      assert_equal err.line, 2
+      assert_equal err.col, 20
+    end
   end
 end


### PR DESCRIPTION
## Problem

I noticed that we got an ArgumentError instead of a parse error when the query string contains a null byte.  This error was coming from [`StringValueCStr`](https://github.com/rmosolgo/graphql-libgraphqlparser-ruby/blob/e56adf4801867cf93eb2f440da103fdc6567d484/ext/graphql_libgraphqlparser_ext/graphql_libgraphqlparser_ext.c#L16) which tries to get a null terminated string to pass to use with libgraphqlparser.
## Solution

I didn't want to impact performance for this edge case by checking for null bytes before parsing the string, so instead I used a `rescue ArgumentError` block to translate the error that ruby raises from `StringValueCStr`.  If the string doesn't have a null byte, then the error is re-raised.

If the string does have a null byte, then a parse error is raised, with String#count used on the slice of the string before the null byte to get the line count and String#rindex to count the characters on the last line to get the column.
