### PR TITLE
Fix null byte error when no new lines in query string

### DIFF
--- a/lib/graphql/libgraphqlparser.rb
+++ b/lib/graphql/libgraphqlparser.rb
@@ -14,7 +14,7 @@ module GraphQL
         if index = string.index("\x00")
           string_before_null = string.slice(0, index)
           line = string_before_null.count("\n") + 1
-          col = index - string_before_null.rindex("\n") || 0
+          col = index - (string_before_null.rindex("\n") || 0)
           raise GraphQL::ParseError.new("Invalid null byte in query", line, col, string)
         end
         raise

--- a/test/graphql/libgraphqlparser_test.rb
+++ b/test/graphql/libgraphqlparser_test.rb
@@ -244,9 +244,18 @@ describe GraphQL::Libgraphqlparser do
       err = assert_raises(GraphQL::ParseError) do
         GraphQL::Libgraphqlparser.parse("mutation{\nsend(message: \"null\x00byte\")\n}")
       end
-      assert_equal err.message, "Invalid null byte in query"
-      assert_equal err.line, 2
-      assert_equal err.col, 20
+      assert_equal "Invalid null byte in query", err.message
+      assert_equal 2, err.line
+      assert_equal 20, err.col
+    end
+
+    it "raises a parse error in query with null byte and no new line" do
+      err = assert_raises(GraphQL::ParseError) do
+        GraphQL::Libgraphqlparser.parse("mutation{send(message: \"null\x00byte\")}")
+      end
+      assert_equal "Invalid null byte in query", err.message
+      assert_equal 1, err.line
+      assert_equal 28, err.col
     end
   end
 end


### PR DESCRIPTION
I believe the intended logic was this ?

`col = index - (string_before_null.rindex("\n") || 0)`

When no new lines were present in the query string, it would 💥 with `"nil can't be coerced into Fixnum"`.

Added a test plus put the expected / actual arguments in the right place :trollface: 

cc @dylanahsmith 
