### PR TITLE
refactor(parse) parse type conditions as nodes, not strings

### DIFF
--- a/ext/graphql_libgraphqlparser_ext/visitor_functions.c
+++ b/ext/graphql_libgraphqlparser_ext/visitor_functions.c
@@ -39,20 +39,6 @@
       )                                       \
     );                                        \
 
-#define ASSIGN_NAMED_TYPE(type)           \
-  rb_funcall(                             \
-    rb_node,                              \
-    type_set_intern,                      \
-    1,                                    \
-    rb_str_new2(                          \
-      GraphQLAstName_get_value(           \
-        GraphQLAstNamedType_get_name(     \
-          type                            \
-        )                                 \
-      )                                   \
-    )                                     \
-  );                                      \
-
 VALUE type_set_intern, name_set_intern, add_value_intern, end_visit_intern, begin_visit_intern, line_set_intern, col_set_intern;
 
 inline void set_node_location(const struct GraphQLAstNode *node, VALUE rb_node) {
@@ -127,8 +113,6 @@ void variable_definition_end_visit(const struct GraphQLAstVariableDefinition* no
 int fragment_definition_begin_visit(const struct GraphQLAstFragmentDefinition* node, void* builder_ptr) {
   BEGIN("FragmentDefinition")
   ASSIGN_NAME(GraphQLAstFragmentDefinition_get_name)
-  const struct GraphQLAstNamedType *type = GraphQLAstFragmentDefinition_get_type_condition(node);
-  ASSIGN_NAMED_TYPE(type)
   return 1;
 }
 
@@ -198,11 +182,6 @@ void fragment_spread_end_visit(const struct GraphQLAstFragmentSpread* node, void
 
 int inline_fragment_begin_visit(const struct GraphQLAstInlineFragment* node, void* builder_ptr) {
   BEGIN("InlineFragment")
-  const struct GraphQLAstNamedType *type = GraphQLAstInlineFragment_get_type_condition(node);
-  if (type) {
-    ASSIGN_NAMED_TYPE(type)
-  }
-
   return 1;
 }
 

--- a/lib/graphql/libgraphqlparser/builder.rb
+++ b/lib/graphql/libgraphqlparser/builder.rb
@@ -40,9 +40,7 @@ module GraphQL
         when Nodes::InlineFragment, Nodes::FragmentSpread, Nodes::Field
           current.selections << node
         when Nodes::TypeName, Nodes::ListType, Nodes::NonNullType
-          # Using ||= because FragmentDefinition has already assigned
-          # this as a plain string :(
-          current.type ||= node
+          current.type = node
         when Nodes::ListLiteral
           # mutability! 🎉
           current.value = node.values

--- a/test/graphql/libgraphqlparser_test.rb
+++ b/test/graphql/libgraphqlparser_test.rb
@@ -51,7 +51,7 @@ describe GraphQL::Libgraphqlparser do
         assert fragment_def.is_a?(GraphQL::Language::Nodes::FragmentDefinition)
         assert_equal "moreNestedFields", fragment_def.name
         assert_equal 1, fragment_def.selections.length
-        assert_equal "NestedType", fragment_def.type
+        assert_equal "NestedType", fragment_def.type.name
         assert_equal 1, fragment_def.directives.length
         assert_equal [17, 5], fragment_def.position
       end
@@ -140,7 +140,7 @@ describe GraphQL::Libgraphqlparser do
       describe "inline fragments" do
         let(:inline_fragment) { query.selections[2] }
         it "gets the type and directives" do
-          assert_equal "OtherType", inline_fragment.type
+          assert_equal "OtherType", inline_fragment.type.name
           assert_equal 2, inline_fragment.selections.length
           assert_equal 1, inline_fragment.directives.length
         end


### PR DESCRIPTION
This is the companion PR for https://github.com/rmosolgo/graphql-ruby/pull/342

It's a breaking change since the AST has a different structure now.
