### PR TITLE
Allow libgraphql parser to optionally be built with cmake

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,6 @@
+[submodule "ext/--force"]
+	path = ext/--force
+	url = https://github.com/graphql/libgraphqlparser
+[submodule "ext/libgraphqlparser"]
+	path = ext/libgraphqlparser
+	url = https://github.com/graphql/libgraphqlparser

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "ext/--force"]
-	path = ext/--force
-	url = https://github.com/graphql/libgraphqlparser
 [submodule "ext/libgraphqlparser"]
 	path = ext/libgraphqlparser
 	url = https://github.com/graphql/libgraphqlparser

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 language: ruby
 cache: bundler
 sudo: required
@@ -8,7 +9,7 @@ rvm:
 addons:
   apt:
     packages:
-    - cmake
+      - cmake
 before_install:
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get -qq update
@@ -17,9 +18,6 @@ before_install:
   - sudo unlink /usr/bin/g++ && sudo ln -s /usr/bin/g++-5 /usr/bin/g++
   - g++ --version
   - sudo apt-get install bison
-  - wget https://github.com/graphql/libgraphqlparser/archive/v0.5.0.tar.gz
-  - tar -xzvf v0.5.0.tar.gz
-  - cd libgraphqlparser-0.5.0/ && sudo cmake . && sudo make && sudo make install
   - gem update --system
   - gem install bundler
 script:

--- a/README.md
+++ b/README.md
@@ -23,15 +23,31 @@ C         0.020000   0.000000   0.020000 (  0.011790)
 
 ## Installation
 
-This gem depends on [libgraphqlparser](https://github.com/graphql/libgraphqlparser) (>= 0.5.0). You can install it a few ways:
+### Option 1
+
+If you have `cmake` installed, we will build [libgraphqlparser](https://github.com/graphql/libgraphqlparser)
+for you.
+
+Just add this to your Gemfile:
+
+```ruby
+gem "graphql-libgraphqlparser"
+```
+
+And you should be good to go 👍
+
+### Option 2
+
+You can install [libgraphqlparser](https://github.com/graphql/libgraphqlparser) (>= 0.5.0)
+yourself. You can install it a few ways:
 
 - Homebrew: `brew install libgraphqlparser`
 - From Source:
 
   ```
-  wget https://github.com/graphql/libgraphqlparser/archive/v0.5.0.tar.gz
-  tar -xzvf v0.5.0.tar.gz
-  cd libgraphqlparser-0.5.0/ && cmake . && make && make install
+  wget https://github.com/graphql/libgraphqlparser/archive/v0.6.0.tar.gz
+  tar -xzvf v0.6.0.tar.gz
+  cd libgraphqlparser-0.6.0/ && cmake . && make && make install
   ```
 
 - With [`heroku-buildpack-libgraphqlparser`](https://github.com/goco-inc/heroku-buildpack-libgraphqlparser)

--- a/ext/graphql_libgraphqlparser_ext/extconf.rb
+++ b/ext/graphql_libgraphqlparser_ext/extconf.rb
@@ -1,7 +1,36 @@
 require 'mkmf'
+require 'fileutils'
 
-prefixes = %w(/usr /usr/local)
-if prefix = prefixes.find{ |prefix| Dir["#{prefix}/lib/libgraphqlparser*"].first }
+def build_libgraphql_parser!(libgraphqlparser_path)
+  cmake = find_executable 'cmake'
+
+  return false unless cmake
+
+  build_path = File.join(libgraphqlparser_path, 'build')
+
+  Dir.chdir(libgraphqlparser_path) do
+    system cmake, "-DCMAKE_INSTALL_PREFIX:PATH=#{build_path}"
+    system 'make'
+    system 'make all install'
+  end
+
+  true
+rescue => e
+  Logging.message "Could not compile libgraphql, got this error : #{e.inspect}"
+  Logging.message "Falling back to local install of libgraphql parser"
+
+  false
+end
+
+libgraphqlparser_path = File.join(__dir__, '..', 'libgraphqlparser')
+
+prefixes = if build_libgraphql_parser!(libgraphqlparser_path)
+             [File.join(libgraphqlparser_path, 'build')]
+           else
+             ['/usr', '/usr/local']
+           end
+
+if prefix = prefixes.find { |prefix| Dir["#{prefix}/lib/libgraphqlparser*"].first }
   dir_config('graphql', "#{prefix}/include/graphqlparser", "#{prefix}/lib")
 else
   dir_config('graphql')

--- a/graphql-libgraphqlparser.gemspec
+++ b/graphql-libgraphqlparser.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
 
   spec.extensions    = ['ext/graphql_libgraphqlparser_ext/extconf.rb']
   spec.files         = `git ls-files -z`.split("\x0")
+  spec.files        += `cd ext/libgraphqlparser && git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']


### PR DESCRIPTION
Manually installing graphql is a big burden for entry for using this gem. It takes time, manual effort, and we can't ensure the version of `libgraphql` parser is compatible.

Many users already have `cmake` and a modern c++ compiler installed on their system. As a result, we can compile `libgraphql` in the gem install process. This makes installing the gem a breeze for many users.

If they do not have cmake, or something goes wrong, we just fall back to the old method of looking up the library. Thus, this PR does not affect users which do not have `cmake`.