### PR TITLE
Add NullValue support

### DIFF
--- a/ext/graphql_libgraphqlparser_ext/graphql_libgraphqlparser_ext.c
+++ b/ext/graphql_libgraphqlparser_ext/graphql_libgraphqlparser_ext.c
@@ -64,4 +64,5 @@ void Init_graphql_libgraphqlparser_ext() {
   ATTACH_CALLBACKS(list_value);
   ATTACH_CALLBACKS(object_value);
   ATTACH_CALLBACKS(object_field);
+  ATTACH_CALLBACKS(null_value);
 }

--- a/ext/graphql_libgraphqlparser_ext/visitor_functions.c
+++ b/ext/graphql_libgraphqlparser_ext/visitor_functions.c
@@ -227,6 +227,16 @@ void named_type_end_visit(const struct GraphQLAstNamedType* node, void* builder_
   end_visit(builder_ptr);
 }
 
+int null_value_begin_visit(const struct GraphQLAstNullValue* node, void* builder_ptr) {
+  VALUE rb_node = build_rb_node((struct GraphQLAstNode*) node, "NullValue", builder_ptr);
+  VALUE rb_string = rb_str_new2("null");
+  rb_funcall(rb_node, name_set_intern, 1, rb_string);
+  return 1;
+}
+
+void null_value_end_visit(const struct GraphQLAstListType* node, void* builder_ptr) {
+  end_visit(builder_ptr);
+}
 
 int float_value_begin_visit(const struct GraphQLAstFloatValue* node, void* builder_ptr) {
   const char* str_float = GraphQLAstFloatValue_get_value(node);

--- a/ext/graphql_libgraphqlparser_ext/visitor_functions.h
+++ b/ext/graphql_libgraphqlparser_ext/visitor_functions.h
@@ -27,5 +27,6 @@ VISITOR_CALLBACKS(enum_value, EnumValue);
 VISITOR_CALLBACKS(list_value, ListValue);
 VISITOR_CALLBACKS(object_value, ObjectValue);
 VISITOR_CALLBACKS(object_field, ObjectField);
+VISITOR_CALLBACKS(null_value, NullValue);
 
 #endif

--- a/graphql-libgraphqlparser.gemspec
+++ b/graphql-libgraphqlparser.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'graphql', '~> 1.0'
+  spec.add_runtime_dependency 'graphql', '~> 1.2'
 
   spec.add_development_dependency 'bundler', '~> 1.0'
   spec.add_development_dependency "guard", "~> 2.12"

--- a/lib/graphql/libgraphqlparser/builder.rb
+++ b/lib/graphql/libgraphqlparser/builder.rb
@@ -44,6 +44,8 @@ module GraphQL
         when Nodes::ListLiteral
           # mutability! 🎉
           current.value = node.values
+        when Nodes::NullValue
+          current.value = node
         when Nodes::InputObject
           current.value = node
         when Nodes::Enum

--- a/test/graphql/libgraphqlparser_test.rb
+++ b/test/graphql/libgraphqlparser_test.rb
@@ -15,7 +15,7 @@ describe GraphQL::Libgraphqlparser do
         field
         anotherField
       }
-
+      aField(anArg: null) { a }
     }
 
     fragment moreNestedFields on NestedType @or(something: "ok") {
@@ -42,7 +42,7 @@ describe GraphQL::Libgraphqlparser do
         assert_equal "getStuff", query.name
         assert_equal "query", query.operation_type
         assert_equal 2, query.variables.length
-        assert_equal 3, query.selections.length
+        assert_equal 4, query.selections.length
         assert_equal 1, query.directives.length
         assert_equal [2, 5], [query.line, query.col]
       end
@@ -95,6 +95,12 @@ describe GraphQL::Libgraphqlparser do
       describe "arguments" do
         let(:literal_argument) { query.selections.first.arguments.last }
         let(:variable_argument) { query.selections.first.arguments.first }
+        let(:null_argument) { query.selections.last.arguments.first }
+
+        it "handles null values for arguments" do
+          assert null_argument.value.is_a?(GraphQL::Language::Nodes::NullValue)
+          assert_equal "null", null_argument.value.name
+        end
 
         it "gets name and literal value" do
           assert_equal "ok", literal_argument.name


### PR DESCRIPTION
Noticed a difference between `libgraphqlparser` and the `racc` default in `graphql-ruby`.

`libgraphqlparser` handles null values but this gem did not handle the values. This PR adds support for it

My `C` skills aren't the best so please feel free to correct some things :)