### PR TITLE
fix extconf when cmake process fails

### DIFF
--- a/ext/graphql_libgraphqlparser_ext/extconf.rb
+++ b/ext/graphql_libgraphqlparser_ext/extconf.rb
@@ -8,10 +8,14 @@ def build_libgraphql_parser!(libgraphqlparser_path)
 
   build_path = File.join(libgraphqlparser_path, 'build')
 
-  Dir.chdir(libgraphqlparser_path) do
-    system cmake, "-DCMAKE_INSTALL_PREFIX:PATH=#{build_path}"
-    system 'make'
-    system 'make all install'
+  make_success = Dir.chdir(libgraphqlparser_path) do
+    system(cmake, "-DCMAKE_INSTALL_PREFIX:PATH=#{build_path}") &&
+    system('make') &&
+    system('make all install')
+  end
+
+  unless make_success
+    raise "Could not make libgraphqlparser at path #{build_path}"
   end
 
   true


### PR DESCRIPTION
`extconf` would not handle the case when `cmake` returns a bad exit status.

This PR now handles that, which falls back properly to local install of libgraphqlparser.