### PR TITLE
Fix extension location override + improve docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# Unreleased
+
+- Support overriding libgraphqlparser install location
+
 # 1.2.0
 
 - Support `tracer:` keyword to `.parse` (supports GraphQL::Tracing) #27

--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ When you `require` this gem, it overrides `GraphQL.parse`:
 require "graphql/libgraphqlparser"
 ```
 
+## Overriding the location of libgraphqlparser
+
+This gem will search for [libgraphqlparser](https://github.com/graphql/libgraphqlparser) at `/usr` and `/usr/local`. If you follow the official install instructions, you don't need to do anything else. If however you have installed libgraphqlparser at a different location, you will need to specify it during gem install. Note that the headers needed to compile the extension are not located at the standard `include` subdirectory but rather `include/graphqlparser`.
+
+Example override:
+
+```bash
+export LIBGRAPHQLPARSER_PATH=/my-custom-path
+gem install graphql-libgraphqlparser -- \
+  --with-graphqlparser-lib=$LIBGRAPHQLPARSER_PATH/lib \
+  --with-graphqlparser-include=$LIBGRAPHQLPARSER_PATH/include/graphqlparser
+```
+
 ## Libgraphqlparser versions
 
 The Ruby gem expects certain versions of `libgraphqlparser` to be installed. I couldn't figure out how to check this in [`extconf.rb`](#), so I documented it here:

--- a/ext/graphql_libgraphqlparser_ext/extconf.rb
+++ b/ext/graphql_libgraphqlparser_ext/extconf.rb
@@ -1,11 +1,12 @@
 require 'mkmf'
 
 prefixes = %w(/usr /usr/local)
-if prefix = prefixes.find{ |prefix| Dir["#{prefix}/lib/libgraphqlparser*"].first }
-  dir_config('graphql', "#{prefix}/include/graphqlparser", "#{prefix}/lib")
+if prefix = prefixes.find{ |candidate| Dir["#{candidate}/lib/libgraphqlparser*"].first }
+  dir_config('graphqlparser', "#{prefix}/include/graphqlparser", "#{prefix}/lib")
 else
-  dir_config('graphql')
+  dir_config('graphqlparser')
 end
+
 abort 'missing libgraphqlparser' unless have_library('graphqlparser')
 abort 'missing libgraphqlparser headers' unless have_header('c/GraphQLParser.h')
 

--- a/ext/graphql_libgraphqlparser_ext/extconf.rb
+++ b/ext/graphql_libgraphqlparser_ext/extconf.rb
@@ -7,7 +7,21 @@ else
   dir_config('graphqlparser')
 end
 
-abort 'missing libgraphqlparser' unless have_library('graphqlparser')
-abort 'missing libgraphqlparser headers' unless have_header('c/GraphQLParser.h')
+LIBRARY_MISSING_ERROR_MESSAGE = <<-EOT
+
+🚨 Could not find libgraphqlparser library. Have you installed it? 🚨
+  See: https://github.com/rmosolgo/graphql-libgraphqlparser-ruby#installation
+
+EOT
+
+HEADER_MISSING_ERROR_MESSAGE = <<-EOT
+
+🚨 Could not find libgraphqlparser headers. Is your library installed in a custom location? 🚨
+  See: https://github.com/rmosolgo/graphql-libgraphqlparser-ruby#overriding-the-location-of-libgraphqlparser
+
+EOT
+
+abort LIBRARY_MISSING_ERROR_MESSAGE unless have_library('graphqlparser')
+abort HEADER_MISSING_ERROR_MESSAGE unless have_header('c/GraphQLParser.h')
 
 create_makefile "graphql_libgraphqlparser_ext"

--- a/ext/graphql_libgraphqlparser_ext/extconf.rb
+++ b/ext/graphql_libgraphqlparser_ext/extconf.rb
@@ -2,8 +2,12 @@ require 'mkmf'
 
 prefixes = %w(/usr /usr/local)
 if prefix = prefixes.find{ |candidate| Dir["#{candidate}/lib/libgraphqlparser*"].first }
+  # This is unorthodox usage of dir_config. The problem is that libgraphqlparser installs its header
+  # files to a subdirectory of include/, so to find them we have to specify a custom "default" location
+  # which is relative to the guessed location of the install. In other words, not a "default" at all.
   dir_config('graphqlparser', "#{prefix}/include/graphqlparser", "#{prefix}/lib")
 else
+  # Failing that, fallback to defaults (/include and /lib)
   dir_config('graphqlparser')
 end
 


### PR DESCRIPTION
Per discussion in #28, after much reading I worked out how to override the config, and have documented it. 

I did made a potential breaking change, if anyone else had deduced the incantation before me, I renamed the flag from `--with-graphql-X` to `--with-graphqlparser-X` as I felt this was more representative of what we are overriding. Can change back if needs be.

I also made the errors more helpful and used some gratuitious emoji to our custom error stands out:
![image](https://user-images.githubusercontent.com/708200/41288683-1340124e-6e3f-11e8-93e6-82a506d6fdc7.png)
